### PR TITLE
MastodonBee - Events account mapping fix and enhanced

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,47 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "make"
+# Binary file yields from `cmd`.
+bin = "beehive"
+# Customize binary.
+full_bin = "APP_ENV=dev APP_USER=air ./beehive"
+# Watch these filename extensions.
+include_ext = ["go", "tpl", "tmpl", "html"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
+# Watch these directories if you specified.
+include_dir = []
+# Exclude files.
+exclude_file = []
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 500 # ms
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#6f1f51",
+    "activityBar.activeBorder": "#5b7d23",
+    "activityBar.background": "#6f1f51",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#5b7d23",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "statusBar.background": "#471434",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#6f1f51",
+    "titleBar.activeBackground": "#471434",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#47143499",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.color": "#471434"
+}

--- a/bees/mastodonbee/events.go
+++ b/bees/mastodonbee/events.go
@@ -109,7 +109,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
 					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{
@@ -153,7 +163,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
 					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{
@@ -187,7 +207,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
-					Value: notif.Status.Account.DisplayName,
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
+					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{
@@ -226,7 +256,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
-					Value: notif.Status.Account.DisplayName,
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
+					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{


### PR DESCRIPTION
- Fixed account mapping for **reblog** and **mention** events.
   - Used `notif.Account` instead of `notif.Status.Account`
- Extended **follow**, **favourite**, **reblog** and **mention** events with two new fields `display_name` and `acct` respectively mapped to the same mastodon API fields
- breaking modification (to be consistent with Mastodon API) on **follow**, **favourite**, **reblog** and **mention** events: 
    - re-mapped `username` from mastodon  API field`display_name` to mastodon API field `username`.